### PR TITLE
Use a better geo_filter in the UTF Grid return

### DIFF
--- a/maps/tiles/gridded.py
+++ b/maps/tiles/gridded.py
@@ -12,9 +12,9 @@ from maps.utils import convert_to_png
 
 class GriddedTile(Tile):
     """
-    The gridded tile style renders a single coloured point representing a group of points within a
-    certain area in the tile. This is done by grouping the points into something like an 8x8 grid,
-    for example. The point colour represents the number of points in the group.
+    The gridded tile style renders a single coloured point representing a group of buckets within a
+    certain area in the tile. This is done by grouping the buckets into something like an 8x8 grid,
+    for example. The point colour represents the number of records in the group.
     """
     style = 'gridded'
 
@@ -41,15 +41,14 @@ class GriddedTile(Tile):
         thresholds = [int(math.exp(i)) for i in range(range_size)]
         return colours[bisect.bisect_left(thresholds, count)]
 
-    def group_points(self, points, grid_resolution):
+    def group_buckets(self, buckets, grid_resolution):
         """
-        Given a list of points, groups them into cells according to the size of the grid (given by
+        Given a list of buckets, groups them into cells according to the size of the grid (given by
         the grid_resolution parameter). A list of lists is returned where each element is a row and
         each element within that is a 2-tuple containing the total records and the first record in
         the cell.
 
-        :param points: a list of 4-tuples, each containing the latitude, longitude, total records at
-                       the coordinate and the first record at the coordinate
+        :param buckets: a list of BucketResult objects
         :param grid_resolution: the resolution of the grid, i.e. how big each cell in the grid
                                 within the tile is. For example, if set to 4 then the returned grid
                                 will be 64x64. This value must result in a grid size that is a power
@@ -67,10 +66,11 @@ class GriddedTile(Tile):
                 row.append([0, None])
             grid.append(row)
 
-        # assign each point a cell in the grid and add its count to the total
-        for latitude, longitude, total, first in points:
+        # assign each bucket a cell in the grid and add its count to the total
+        for bucket in buckets:
             # translate to x and y coordinates within the tile's bounds on the grid's scale
-            x, y = self.translate_to_tile(latitude, longitude, cell_ratio)
+            x, y = self.translate_to_tile(bucket.centre_latitude, bucket.centre_longitude,
+                                          cell_ratio)
 
             # ignore out of bounds points
             if x < 0 or x >= grid_size or y < 0 or y >= grid_size:
@@ -81,23 +81,22 @@ class GriddedTile(Tile):
             y = int(y)
 
             # add the data to the grid
-            grid[y][x][0] += total
+            grid[y][x][0] += bucket.total
             # set the first if it hasn't already been set
             if grid[y][x][1] is None:
-                grid[y][x][1] = first
+                grid[y][x][1] = bucket.first_record
 
         return grid
 
-    def as_image(self, points, *args, **kwargs):
-        return self.render(points, *args, **kwargs)
+    def as_image(self, buckets, *args, **kwargs):
+        return self.render(buckets, *args, **kwargs)
 
-    def render(self, points, grid_resolution, cold_colour, hot_colour, range_size, resize_factor):
+    def render(self, buckets, grid_resolution, cold_colour, hot_colour, range_size, resize_factor):
         """
-        Renders the series of latitude and longitude points onto a grid, weighing the colour of the
-        point in each cell of the grid using the total count of points in it.
+        Renders the series of buckets onto a grid, weighing the colour of the bucket in each cell of
+        the grid using the total count of records in it.
 
-        :param points: a list of 4-tuples, each containing the latitude, longitude, total records at
-                       the coordinate and the first record at the coordinate
+        :param buckets: a list of BucketResult objects
         :param grid_resolution: the resolution of the grid, i.e. how big in pixels each cell should
                                 be
         :param cold_colour: the colour to assign to the lowest count (1)
@@ -115,7 +114,7 @@ class GriddedTile(Tile):
         # create a new image object the size of the scaled up tile
         image = Image.new('RGBA', (self.width * resize_factor, self.height * resize_factor))
 
-        for y, row in enumerate(self.group_points(points, grid_resolution)):
+        for y, row in enumerate(self.group_buckets(buckets, grid_resolution)):
             for x, (count, _first) in enumerate(row):
                 colour = self.assign_colour(count, cold_colour, hot_colour, range_size)
                 if colour is None:
@@ -131,24 +130,21 @@ class GriddedTile(Tile):
 
         return convert_to_png(image)
 
-    def get_marks(self, points, grid_resolution):
+    def get_marks(self, buckets, grid_resolution):
         """
         Returns a generator of coordinates to be marked in the UTFGrid produced by the as_grid
-        function. Each element yielded is a 6-tuple of latitude, longitude, x, y, total and first,
-        where latitude and longitude mark the real world points of the mark, x and y mark the cell
-        coordinates within the grid, total is the total number of records at the mark and first
-        represents the first record found at the mark.
+        function. Each element yielded is a 3-tuple of a point data dict, x, and y where the point
+        data dict is the data dict to associate with the x and y coordinate in the utf grid result,
+        and x and y are the cell coordinates within the grid.
 
-        :param points: a list of 4-tuples, each containing the latitude, longitude, total records at
-                       the coordinate and the first record at the coordinate
+        :param buckets: a list of BucketResult objects
         :param grid_resolution: the resolution of the grid, i.e. how big each cell in the grid
                                 within the tile is. For example, if set to 4 then the returned grid
                                 will be 64x64. This value must result in a grid size that is a power
                                 of 2.
-        :return: an iterable where each element is a 6-tuple of latitude, longitude, x, y, total and
-                 first
+        :return: an iterable where each element is a 3-tuple of point data, x, and y
         """
-        for y, row in enumerate(self.group_points(points, grid_resolution)):
+        for y, row in enumerate(self.group_buckets(buckets, grid_resolution)):
             for x, (total, first) in enumerate(row):
                 if total == 0:
                     continue
@@ -156,4 +152,12 @@ class GriddedTile(Tile):
                 # centre of the cell but it's probably not worth the time it would take to calculate
                 # this
                 latitude, longitude = map(float, first['meta']['geo'].split(','))
-                yield latitude, longitude, x, y, total, first
+
+                point_data = {
+                    'count': total,
+                    'data': first['data'],
+                    'record_latitude': latitude,
+                    'record_longitude': longitude,
+                }
+
+                yield point_data, x, y

--- a/maps/tiles/heatmap.py
+++ b/maps/tiles/heatmap.py
@@ -11,16 +11,16 @@ from maps.utils import clamp, convert_to_png
 
 class HeatmapTile(Tile):
     """
-    The heatmap tile style renders a more overall picture by blending the points out across the tile
-    with areas where there are lots of points at the red end of the spectrum and areas where there
-    are small numbers of points at the blue end of the spectrum.
+    The heatmap tile style renders a more overall picture by blending the buckets out across the
+    tile with areas where there are lots of records at the red end of the spectrum and areas where
+    there are smaller numbers of records at the blue end of the spectrum.
     """
     style = 'heatmap'
 
-    def as_image(self, points, *args, **kwargs):
-        return self.render(points, *args, **kwargs)
+    def as_image(self, buckets, *args, **kwargs):
+        return self.render(buckets, *args, **kwargs)
 
-    def render(self, points, point_radius, cold_colour, hot_colour, intensity):
+    def render(self, buckets, point_radius, cold_colour, hot_colour, intensity):
         # create the colour range from blue through to red. This range has the same number of
         # colours in it as the allowed alpha range (i.e. 256 distinct values). This importantly
         # includes (0, 0, 0, 0) in index 0
@@ -34,12 +34,12 @@ class HeatmapTile(Tile):
                                    self.height + (point_diameter * 2)))
 
         # loop through all the point pairs
-        for latitude, longitude, total, _first in points:
+        for bucket in buckets:
             # translate to x and y coordinates within the tile's bounds
-            x, y = self.translate_to_tile(latitude, longitude, 1)
+            x, y = self.translate_to_tile(bucket.centre_latitude, bucket.centre_longitude, 1)
             # clamp the log of the total to the 1-10 range. This prevents us from giving huge totals
             # too much importance and ensures all totals are represented sensibly
-            weight = clamp(int(math.log(total)), 1, 10)
+            weight = clamp(int(math.log(bucket.total)), 1, 10)
             point = draw_heatmap_point(point_radius, weight, intensity)
             # merge it into the image at the position required. The translated the coordinates are
             # to ensure we draw the point in the right place (this is a simplified version of


### PR DESCRIPTION
Prior to this we were returning a 1m radius point as the geo filter if there were multiple records at the same point, now we're actually using the bounding box of the bucket the records are all in.

This required a minor refactor, resulting in any reference in the tiles code to "points" changing to "buckets". Makes a bit more sense now.

Closes: https://github.com/NaturalHistoryMuseum/versioned-datastore-tile-server/issues/1